### PR TITLE
type safety

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -109,7 +109,7 @@ function replace(pattern, data){
 
   for (var i = 0, key; key = keys[i++];) {
     if (!data[key]) return null;
-    ret[key] = slug(data[key]);
+    ret[key] = slug(data[key].toString());
   }
 
   return substitute(pattern, ret);


### PR DESCRIPTION
added toString() conversion because yaml-js types everything it can (e.g. timestamp -> Date object)
