### PR TITLE
Replaced GIT repository by archive URL of the substitute releases 0.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "slug-component": "~1.1.0",
     "debug": "~0.7.4",
-    "substitute": "git://github.com/segmentio/substitute#0.0.1",
+    "substitute": "https://github.com/segmentio/substitute/archive/0.0.1.tar.gz",
     "moment": "^2.5.1"
   },
   "devDependencies": {


### PR DESCRIPTION
When using metalsmith-permalinks, we faced an issue our dev infrastructure where we have proxies that forbid us to use git URL to clone repositories specified in package.json.

One possibility to solve the issue is to release segmentio/substitute dependency but it seems there is already one another project published on npmjs.org and then, it will not be possible to release under that name.

We found a workaround by replacing the git URL to the repo by the archive URL to downloaded the node module as a tar gz.
